### PR TITLE
Add worker argument to before_first_fork hook

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -272,7 +272,7 @@ module Resque
       enable_gc_optimizations
       register_signal_handlers
       prune_dead_workers
-      run_hook :before_first_fork
+      run_hook :before_first_fork, self
       register_worker
 
       # Fix buffering so we can `rake resque:work > resque.log` and


### PR DESCRIPTION
before_first_fork is worker-specific and sometimes
a worker reference is needed for the hook's logic.
