### PR TITLE
Add support for weighted queues

### DIFF
--- a/lib/resque/errors.rb
+++ b/lib/resque/errors.rb
@@ -8,6 +8,9 @@ module Resque
   # Raised when a worker was killed while processing a job.
   class DirtyExit < RuntimeError; end
 
+  # Raised when we want shuffling but weights are not provided.
+  class NoWeightError < RuntimeError; end
+
   # Raised when child process is TERM'd so job can rescue this to do shutdown work.
   class TermException < SignalException; end
 end


### PR DESCRIPTION
Add support for weighted queues

Introdude shuffle strategy for when resque reserves a job. This allows for
random queue order and therefore for all queues to reserve time to complete
jobs without having to wait for the higher order ones to empty.

By default the feature is off, which means the default strategy is not
affected.

Example to enable:

Replace `QUEUES=high,medium,low` with `QUEUES=high=3,medium=2,low=1` in order
to allow `medium` and `low` queues to also perform but in a lower frequency, 
without having to wait for `high` to empty.

Closes T3372