### PR TITLE
Improve shuffling algorithm

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -276,9 +276,28 @@ module Resque
     def shuffled_queues
       return nil unless shuffling_enabled?
 
-      queues.sort_by do |queue|
-        rand() * @weights[queue]
-      end.reverse
+      weight_per_queue = @weights.dup
+
+      queues = []
+      while weight_per_queue.size > 1
+        picked = pick_random_queue(weight_per_queue)
+        weight_per_queue.delete(picked)
+        queues << picked
+      end
+      queues << weight_per_queue.keys.first
+
+      queues
+    end
+
+    def pick_random_queue(weight_per_queue)
+      total_weight = weight_per_queue.values.reduce(:+)
+      take = rand(0...total_weight)
+
+      accumulator = 0
+      weight_per_queue.each do |q, w|
+        return q if take < accumulator + w
+        accumulator += w
+      end
     end
 
     def shuffling_enabled?


### PR DESCRIPTION
The current version does not produce the right frequencies in which the
jobs should be performed.

The new version implements a more complicated algorithm which produces the
expected results.

Examples:

`QUEUES=high=1,medium=1,low=1` is expected to consume one job from each queue
every third time (33.3%).

`QUEUES=high=2,medium=1,low=1` is expected to give high ~50% chance
for being first and 25% for medium and low.

`QUEUES=high=3,medium=2,low=1` is expected to give high 50% chance
for being first, 33% for medium and 17% for low.

NOTE: For the last example the current version will produce 65% for high,
30% for medium and 5% for low.