### PR TITLE
Multiple failure backend guard errors

### DIFF
--- a/lib/resque/failure/multiple.rb
+++ b/lib/resque/failure/multiple.rb
@@ -22,7 +22,16 @@ module Resque
       end
 
       def save
-        @backends.each(&:save)
+        exception = nil
+        @backends.each do |b|
+          begin
+            b.save
+          rescue => e
+            exception = e
+            log("Failed saving to #{b.class.name}, error #{e.to_s}")
+          end
+        end
+        raise exception if exception
       end
 
       # The number of failures.

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  Version = VERSION = '1.23.0.1.skroutz.15'
+  Version = VERSION = '1.23.0.1.skroutz.16'
 end

--- a/test/resque_failure_multiple_test.rb
+++ b/test/resque_failure_multiple_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+require 'resque/failure/redis'
+require 'resque/failure/extra'
+require 'resque/failure/multiple'
+
+module Resque
+  module Failure
+    # A failure backend that only raises errors on save
+    class ExceptionRaiser < Base
+      extend Resque::Failure::Extra
+
+      def save
+        raise StandardError.exception("Bazinga on save")
+      end
+    end
+  end
+end
+
+context "Resque::Failure::Multiple" do
+  setup do
+    exception      = StandardError.exception("This is a test")
+    worker         = Resque::Worker.new(:test)
+    queue          = "queue"
+    payload        = { "class" => Object, "args" => 3 }
+
+    Resque::Failure::Redis.clear #clear redis backends from any previously saved failures
+
+    Resque::Failure::Multiple.configure do |config|
+      config.classes = [Resque::Failure::ExceptionRaiser,Resque::Failure::Redis]
+    end
+
+    @multi = Resque::Failure::Multiple.new(exception, worker, queue, payload)
+  end
+
+  test 'catches exceptions during backend.save and re-raises after all backends have tried to save' do
+    assert_raise StandardError do
+      @multi.save
+    end
+    assert_equal 1, Resque::Failure::Redis.count # Backends registered other than ExceptionRaiser should have saved the failure correctly.
+  end
+end


### PR DESCRIPTION
Each individual `backend.save` execution is rescued so that all backends
get a chance to save each failure.

After all saves have finished the multiple backend re-raises the last
seen exception.