### PR TITLE
Remove weighted queues

### DIFF
--- a/lib/resque/errors.rb
+++ b/lib/resque/errors.rb
@@ -16,9 +16,6 @@ module Resque
   end
   class PruneDeadWorkerDirtyExit < DirtyExit; end
 
-  # Raised when we want shuffling but weights are not provided.
-  class NoWeightError < RuntimeError; end
-
   # Raised when child process is TERM'd so job can rescue this to do shutdown work.
   class TermException < SignalException; end
 end

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  Version = VERSION = '1.23.0.1.skroutz.16'
+  Version = VERSION = '1.27.4.skroutz.0'
 end


### PR DESCRIPTION
This branch removes the weighted queues functionality and and is on top of upstream-1.27.4 which has been synced from upstream resque/resque version 1.27.4.
Weighted queues have been removed according to https://phabricator.skroutz.gr/T24325