### PR TITLE
Set blacklisted exceptions

### DIFF
--- a/lib/resque/failure/base.rb
+++ b/lib/resque/failure/base.rb
@@ -17,11 +17,26 @@ module Resque
       # The payload object associated with the failed job
       attr_accessor :payload
 
+      # The exceptions that will not be pushed to failed queue
+      attr_reader :blacklisted_exceptions
+
       def initialize(exception, worker, queue, payload)
         @exception = exception
         @worker    = worker
         @queue     = queue
         @payload   = payload
+        @blacklisted_exceptions = []
+      end
+
+      # Set a list of blacklisted exceptions
+      #
+      # The method sets a list of exceptions which will
+      # not be pushed to the failed queue when a job fails and it's
+      # exception is included to the blacklisted ones.
+      #
+      # @param [Array<String>] exceptions the list of exceptions to blacklist
+      def set_blacklisted_exceptions(exceptions)
+        @blacklisted_exceptions = exceptions
       end
 
       # When a job fails, a new instance of your Failure backend is created

--- a/lib/resque/failure/multiple.rb
+++ b/lib/resque/failure/multiple.rb
@@ -9,6 +9,7 @@ module Resque
 
       class << self
         attr_accessor :classes
+        attr_accessor :blacklisted_exceptions
       end
 
       def self.configure
@@ -19,6 +20,11 @@ module Resque
       def initialize(*args)
         super
         @backends = self.class.classes.map {|klass| klass.new(*args)}
+        @backends.each do |b|
+          if b.respond_to?(:set_blacklisted_exceptions)
+            b.set_blacklisted_exceptions(self.class.blacklisted_exceptions)
+          end
+        end
       end
 
       def save

--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -25,6 +25,11 @@ module Resque
           :worker    => worker.to_s,
           :queue     => queue
         }
+
+        if !blacklisted_exceptions.nil?
+          return if blacklisted_exceptions.include?(data[:exception])
+        end
+
         data = Resque.encode(data)
         data_store.push_to_failed_queue(data)
       end

--- a/lib/resque/failure/redis_multi_queue.rb
+++ b/lib/resque/failure/redis_multi_queue.rb
@@ -22,6 +22,11 @@ module Resque
           :worker    => worker.to_s,
           :queue     => queue
         }
+
+        if !blacklisted_exceptions.nil?
+          return if blacklisted_exceptions.include?(data[:exception])
+        end
+
         data = Resque.encode(data)
         data_store.push_to_failed_queue(data,Resque::Failure.failure_queue_name(queue))
       end

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  Version = VERSION = '1.27.4.skroutz.1'
+  Version = VERSION = '1.27.4.skroutz.2'
 end

--- a/test/failure_base_test.rb
+++ b/test/failure_base_test.rb
@@ -6,10 +6,25 @@ require 'resque/failure/base'
 class TestFailure < Resque::Failure::Base
 end
 
+class CustomException < StandardError; end
+
 describe "Base failure class" do
   it "allows calling all without throwing" do
     with_failure_backend TestFailure do
       assert_empty Resque::Failure.all
     end
+  end
+
+  it "sets a list of blacklisted exceptions" do
+    blacklisted_exceptions = [CustomException].map(&:name).map(&:to_s)
+    exc = CustomException.new("Custom Exception error occured")
+    queue = 'my-queue'
+    worker = Resque::Worker.new([queue])
+    payload = {"find" => "MyModel.find(100)"}
+
+    t = TestFailure.new(exc, worker, queue, payload)
+    t.set_blacklisted_exceptions(blacklisted_exceptions)
+
+    assert_equal blacklisted_exceptions, t.blacklisted_exceptions
   end
 end


### PR DESCRIPTION
This pull request allows external sources to set a list of exceptions that should not be pushed to
the failed queue when a failed job occurs. `Resque::Failure::Multiple` allows setting the `blacklisted_exceptions` attribute which on initialization propagates the blacklisted exception on
every configured backend (set by `classes` attribute). Then `save` method of each backend determines
if a failed job should be pushed to the failed queue or not based on the configured blacklisted exceptions.