### PR TITLE
Set blacklisted exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.2
   - 2.3.0
+  - 2.3.3
+  - 2.5.5
 sudo: false
-matrix:
-  include:
-    - rvm: 1.8.7
-      gemfile: Gemfiles/Gemfile.1.8.7

--- a/lib/resque/failure/base.rb
+++ b/lib/resque/failure/base.rb
@@ -1,3 +1,5 @@
+require 'resque/failure/blacklist_exceptions_registrar'
+
 module Resque
   module Failure
     # All Failure classes are expected to subclass Base.
@@ -5,6 +7,8 @@ module Resque
     # When a job fails, a new instance of your Failure backend is created
     # and #save is called.
     class Base
+      include BlacklistExceptionsRegistrar
+
       # The exception object raised by the failed job
       attr_accessor :exception
 

--- a/lib/resque/failure/blacklist_exceptions_registrar.rb
+++ b/lib/resque/failure/blacklist_exceptions_registrar.rb
@@ -1,0 +1,50 @@
+module Resque
+  module Failure
+    # A module to access blacklisted exceptions
+    # on a class level
+    module BlacklistExceptionsRegistrar
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      # Class methods for accessing
+      # blacklisted exceptions
+      module ClassMethods
+        # Set a list of blacklisted exceptions
+        #
+        # The method sets a list of exceptions which will
+        # not be pushed to the failed queue when a job fails and it's
+        # exception is included to the blacklisted ones.
+        #
+        # @param [Array<String>] exceptions the list of exceptions to blacklist
+        # @raise [StandardError] if the exceptions argument is not an array
+        # @return [void]
+        def set_blacklisted_exceptions(exceptions)
+          unless exceptions.is_a?(Array)
+            raise StandardError.new("The exceptions argument must be an array")
+          end
+
+          @blacklist = exceptions
+        end
+
+        # Fetch the blacklisted exceptions of a failure backend class
+        #
+        # @return [Array<String>]
+        def get_blacklisted_exceptions
+          return @blacklist if defined?(@blacklist)
+
+          []
+        end
+      end
+
+      # Check if the raised exception belongs
+      # to the backend's blacklisted exceptions.
+      #
+      # @return [true, false] true if raised exception is blacklisted,
+      #   false otherwise
+      def blacklisted_exception_raised?
+        self.class&.get_blacklisted_exceptions&.include?(@exception.class.to_s)
+      end
+    end
+  end
+end

--- a/lib/resque/failure/multiple.rb
+++ b/lib/resque/failure/multiple.rb
@@ -25,7 +25,7 @@ module Resque
         exception = nil
         @backends.each do |b|
           begin
-            b.save
+            b.save unless b.blacklisted_exception_raised?
           rescue => e
             exception = e
             log("Failed saving to #{b.class.name}, error #{e.to_s}")

--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -16,6 +16,8 @@ module Resque
       end
 
       def save
+        return if blacklisted_exception_raised?
+
         data = {
           :failed_at => UTF8Util.clean(Time.now.strftime("%Y/%m/%d %H:%M:%S %Z")),
           :payload   => payload,

--- a/lib/resque/failure/redis_multi_queue.rb
+++ b/lib/resque/failure/redis_multi_queue.rb
@@ -13,6 +13,8 @@ module Resque
       end
 
       def save
+        return if blacklisted_exception_raised?
+
         data = {
           :failed_at => Time.now.strftime("%Y/%m/%d %H:%M:%S %Z"),
           :payload   => payload,

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  Version = VERSION = '1.27.4.skroutz.1'
+  Version = VERSION = '1.27.4.skroutz.2'
 end

--- a/test/resque_failure_multiple_test.rb
+++ b/test/resque_failure_multiple_test.rb
@@ -16,6 +16,8 @@ module Resque
   end
 end
 
+class CustomException < StandardError; end
+
 describe "Resque::Failure::Multiple" do
 
   it 'requeue_all and does not raise an exception' do
@@ -62,3 +64,22 @@ describe "Resque::Failure::Multiple" do
     end
   end
 end
+
+describe "blacklisted_exceptions" do
+  it "sets blacklisted_exceptions on the multiple backend" do
+    blacklisted_exceptions = ["CustomException"]
+    Resque::Failure::Redis.set_blacklisted_exceptions(blacklisted_exceptions)
+    Resque::Failure::Multiple.classes = [Resque::Failure::Redis]
+
+    exception = CustomException.new("Custom error")
+    worker = Resque::Worker.new(:test)
+    payload = { "class" => Object, "args" => 3 }
+
+    multiple_backend = Resque::Failure::Multiple.new(exception, worker, 'test', payload)
+    backends = multiple_backend.instance_variable_get(:@backends)
+    backends.each do |b|
+      assert_equal blacklisted_exceptions, b.class.get_blacklisted_exceptions
+    end
+  end
+end
+


### PR DESCRIPTION
This pull request allows accessing/modifying of a blacklist of exceptions of a Resque Failure backend
which is a class variable of a Resque::Failure::Base class. So, each backend by calling `set_blacklisted_exceptions` on the class, can set its `monitored` blacklisted exceptions and this is independent of the backend class (e.g Redis might have its own exceptions and a RedisMultiQueue might have its own and they can also later be added to a Multiple backend if a user needs many failure backends)