### PR TITLE
gem: Use our version for redis-namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 1.9.3
   - 2.2
   - 2.3.0
+  - 2.5.5
 sudo: false
 matrix:
   include:

--- a/resque.gemspec
+++ b/resque.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = [ "LICENSE", "README.markdown" ]
   s.rdoc_options      = ["--charset=UTF-8"]
 
-  s.add_dependency "redis-namespace", "~> 1.3"
+  s.add_dependency "redis-namespace", '1.6.0.skroutz.1'
   s.add_dependency "vegas", "~> 0.1.2"
   s.add_dependency "sinatra", ">= 0.9.2"
   s.add_dependency "multi_json", "~> 1.0"

--- a/resque.gemspec
+++ b/resque.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = [ "LICENSE", "README.markdown" ]
   s.rdoc_options      = ["--charset=UTF-8"]
 
-  s.add_dependency "redis-namespace", '1.6.0.skroutz.1'
+  s.add_dependency "redis-namespace", "~> 1.3"
   s.add_dependency "vegas", "~> 0.1.2"
   s.add_dependency "sinatra", ">= 0.9.2"
   s.add_dependency "multi_json", "~> 1.0"


### PR DESCRIPTION
Our projects use a fork of redis-namespace gem.

We need to use that explicitly in order to properly run
the tests locally.

https://github.skroutz.gr/skroutz/yogurt/blob/master/Gemfile#L94
https://github.skroutz.gr/skroutz/metrix/blob/master/Gemfile#L47