### PR TITLE
Add support for suspending & killing jobs

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -9,6 +9,9 @@ require 'resque/errors'
 require 'resque/failure'
 require 'resque/failure/base'
 
+require 'resque/job_removal'
+require 'resque/worker_job_removal'
+
 require 'resque/helpers'
 require 'resque/stat'
 require 'resque/logging'
@@ -25,6 +28,7 @@ require 'resque/vendor/utf8_util'
 
 module Resque
   include Helpers
+  include JobRemoval
   extend self
 
   # Given a Ruby object, returns a string suitable for storage in a

--- a/lib/resque/job_removal.rb
+++ b/lib/resque/job_removal.rb
@@ -1,0 +1,50 @@
+module Resque
+  module JobRemoval
+    SUSPEND_OPS_KEY = 'suspend_ops'.freeze
+    KILL_OPS_KEY = 'kill_ops'.freeze
+
+    # Instruct all workers to kill their current running job
+    # if it matches the given class or class + smart id.
+    #
+    # The smart id can be a string which will be used by a custom
+    # smart id matcher to identify & kill a subset of the class's jobs.
+    def killall(klass, smart_id = nil)
+      data_store.multi do |multi|
+        multi.sadd(KILL_OPS_KEY, [Time.now.to_i, klass, smart_id].compact.join('/'))
+        multi.expire(KILL_OPS_KEY, 60)
+      end
+    end
+
+    # Instruct all workers to start suspending the jobs
+    # if they match the given class or class + smart id.
+    #
+    # The smart id can be a string which will be used by a custom
+    # smart id matcher to identify & suspend a subset of the class's jobs.
+    def start_suspending(name, klass, smart_id = nil)
+      data_store.sadd(SUSPEND_OPS_KEY, [name, klass, smart_id].compact.join('/'))
+    end
+
+    # Instruct all workers to stop suspending the jobs
+    # of the given operation name.
+    def stop_suspending(name)
+      so = data_store.smembers(SUSPEND_OPS_KEY).find { |so| so.split('/').first == name }
+      raise "Cannot find suspend operation '#{name}'" if so.nil?
+
+      data_store.srem(SUSPEND_OPS_KEY, so)
+    end
+
+    # Get a list of the active suspend operations by their name
+    def suspend_operations
+      data_store.smembers(SUSPEND_OPS_KEY)
+    end
+
+    # Requeue the suspended jobs by their name
+    def requeue_suspended(name, dst_queue)
+      src_queue = "suspended:#{name}"
+
+      while (job = pop(src_queue))
+        Job.create(dst_queue, job['class'], *job['args'])
+      end
+    end
+  end
+end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -14,6 +14,7 @@ module Resque
     include Resque::Helpers
     extend Resque::Helpers
     include Resque::Logging
+    prepend Resque::WorkerJobRemoval
 
     @@all_heartbeat_threads = []
     def self.kill_all_heartbeat_threads

--- a/lib/resque/worker_job_removal.rb
+++ b/lib/resque/worker_job_removal.rb
@@ -1,0 +1,115 @@
+module Resque
+  module WorkerJobRemoval
+    def self.prepended(base)
+      base.extend SmartIdExtractor
+    end
+
+    module SmartIdExtractor
+      attr_accessor :smart_id_extractor
+    end
+
+    def startup
+      super
+      start_kill_operations_thread if fork_per_job?
+    end
+
+    def perform_with_fork(job, &block)
+      @last_fork_time = Time.now.to_i
+      super
+    end
+
+    def work_one_job(job = nil, &block)
+      return false if paused?
+      return false unless job ||= reserve
+
+      if (name = suspend?(job))
+        Job.create("suspended:#{name}", job.payload['class'], *job.payload['args'])
+        return true
+      end
+
+      super(job, &block)
+    end
+
+    def queues
+      super.reject { |queue| queue.start_with?('suspended:') }
+    end
+
+    def extract_smart_id(job_payload)
+      if !(km = self.class.smart_id_extractor).nil?
+        km.call(job_payload)
+      else
+        nil
+      end
+    end
+
+    def job_matches_op?(job_class, job_smart_id, class_of_op, smart_id_of_op)
+      if job_smart_id && smart_id_of_op
+        job_class == class_of_op && job_smart_id == smart_id_of_op
+      else
+        job_class == class_of_op
+      end
+    end
+
+    # Check the suspend operations placed using Resque.start_suspending for matching
+    # with the given job. If there is a match, return the operation's name.
+    def suspend?(job)
+      return false unless job.payload.is_a?(Hash) && job.payload['class']
+
+      suspend_ops = data_store.smembers('suspend_ops')
+      return false if suspend_ops.empty?
+
+      jobs_to_suspend = suspend_ops.map do |so|
+        so.split('/')
+      end
+
+      job_class = job.payload['class']
+      job_smart_id = extract_smart_id(job.payload)
+
+      matching_op = jobs_to_suspend.find do |(_name, class_to_suspend, smart_id_to_suspend)|
+        job_matches_op?(job_class, job_smart_id, class_to_suspend, smart_id_to_suspend)
+      end
+
+      return false unless matching_op
+      matching_op.first
+    end
+
+    # Check every 5 seconds the kill operations placed by Resque.killall and kill
+    # the current running child if the job matches the given class or class + smart id.
+    def start_kill_operations_thread
+      @kill_operations_thread = Thread.new do
+        loop do
+          sleep 5
+
+          child = defined?(@child) ? @child : nil
+          j = job
+
+          next unless child
+          next unless j['payload'].is_a?(Hash) && j['payload']['class']
+
+          candidate_kill_ops = data_store.smembers('kill_ops').select do |k|
+            k.split('/').first.to_i > @last_fork_time
+          end
+
+          next if candidate_kill_ops.empty?
+
+          jobs_to_kill = candidate_kill_ops.map { |cko| cko.split('/')[1..2] }
+
+          curr_job_class = j['payload']['class']
+          curr_job_smart_id = extract_smart_id(j['payload'])
+
+          should_kill_child = jobs_to_kill.any? do |jtk|
+            class_to_kill, smart_id_to_kill = jtk
+
+            job_matches_op?(curr_job_class, curr_job_smart_id, class_to_kill, smart_id_to_kill)
+          end
+
+          begin
+            Process.kill('KILL', child) if should_kill_child
+          rescue Errno::ESRCH # No such process
+            next
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/worker_job_removal_test.rb
+++ b/test/worker_job_removal_test.rb
@@ -1,0 +1,118 @@
+require 'test_helper'
+
+KILLALL_TESTFILE = '/tmp/resque_kill_thread_test'
+
+describe 'Resque::WorkerJobRemoval' do
+  class SlowJob
+    def self.perform
+      $slow_job_started = true
+      sleep 10
+      File.write(KILLALL_TESTFILE, 'touch')
+    end
+  end
+
+  before do
+    $slow_job_started = false
+    @worker = Resque::Worker.new('*')
+    @worker.start_kill_operations_thread
+  end
+
+  after do
+    File.delete(KILLALL_TESTFILE) rescue nil
+  end
+
+  it 'is able to kill only the jobs of a given Class' do
+    File.delete('/tmp/resque_kill_thread_test') rescue nil
+
+
+    Resque::Job.create(:jobs, GoodJob)
+    Resque::Job.create(:jobs, SlowJob)
+
+    assert_equal 2, Resque.size(:jobs)
+
+    Thread.new do
+      sleep 1
+      Resque.killall('SlowJob')
+    end
+
+    assert_equal true, @worker.work_one_job
+    assert_equal true, @worker.work_one_job
+
+    assert_equal false, File.exists?(KILLALL_TESTFILE)
+    assert_equal 0, Resque.size(:jobs)
+  end
+
+  it 'is able to kill only the jobs of a given Class + Smart Id' do
+    File.delete('/tmp/resque_kill_thread_test') rescue nil
+
+    Resque::Job.create(:jobs, GoodJob)
+    Resque::Job.create(:jobs, SlowJob, 'arg1')
+    Resque::Worker.smart_id_extractor = ->(job_payload) do
+      job_payload['args'].first
+    end
+
+    assert_equal 2, Resque.size(:jobs)
+
+    Thread.new do
+      while $slow_job_started == false
+        sleep 0.1
+      end
+
+      Resque.killall('SlowJob', 'arg1')
+    end
+
+    assert_equal true, @worker.work_one_job
+    assert_equal true, @worker.work_one_job
+
+    assert_equal false, File.exists?(KILLALL_TESTFILE)
+    assert_equal 0, Resque.size(:jobs)
+
+    Resque::Worker.smart_id_extractor = nil
+  end
+
+  it 'is able to suspend only the jobs of a given Class' do
+    Resque::Job.create(:jobs, GoodJob)
+    Resque::Job.create(:jobs, BadJob)
+
+    assert_equal 2, Resque.size(:jobs)
+
+    Resque.start_suspending('test', 'BadJob')
+
+    assert_equal true, @worker.work_one_job
+    assert_equal true, @worker.work_one_job
+
+    assert_equal 1, Resque.size('suspended:test')
+    assert_equal 0, Resque.size(:jobs)
+  end
+
+  it 'is able to suspend only the jobs of a given Class + Smart Id' do
+    Resque::Job.create(:jobs, GoodJob)
+    Resque::Job.create(:jobs, BadJob, 'arg1')
+    Resque::Worker.smart_id_extractor = ->(job_payload) do
+      job_payload['args'].first
+    end
+
+    assert_equal 2, Resque.size(:jobs)
+
+    Resque.start_suspending('test', 'BadJob', 'arg1')
+
+    assert_equal true, @worker.work_one_job
+    assert_equal true, @worker.work_one_job
+
+    assert_equal 1, Resque.size('suspended:test')
+    assert_equal 0, Resque.size(:jobs)
+
+    Resque::Worker.smart_id_extractor = nil
+  end
+
+  it 'does not reserve jobs from queues starting with `suspended:`' do
+    Resque::Job.create(:jobs, GoodJob)
+    Resque::Job.create('suspended:test', BadJob)
+
+    assert_equal true, @worker.work_one_job
+    assert_equal false, @worker.work_one_job
+
+    assert_equal 1, Resque.size('suspended:test')
+    assert_equal 0, Resque.size(:jobs)
+  end
+end


### PR DESCRIPTION
### Support for killing a type of the currently running jobs:

A thread will run on each worker checking for kill operations redis key describing the currently running jobs to kill.
If a kill operation matches the current job's class or smart id then the worker will kill its child process.

A kill operation can be placed with:
```ruby
Resque.killall('<class>', '<method>') # method is optional
```
----------------------------------------------------------------------

### Support for suspending a type of jobs:

Suspending means that the resque worker will not run the jobs matching the given criteria and instead will place them into a `suspended:<incident name>`new queue which cannot be consumed.

Suspend operations can be started with:
```ruby
Resque.start_suspending('incident name', '<class>', '<method>')
```
And stopped with:
```ruby
Resque.stop_suspending('incident name')
```
Suspended jobs can be requeued to a consumable queue with:
```ruby
Resque.requeue_suspended('incident name', <queue>)
  ```
--------------------------------------------------------------------
### Smart Id Extractor
In resque's semantics,  the optional `<method>` argument is abstracted as `smart_id`. 
Therefore, the mapping to `<method>` should be provided by the application:
```ruby
Resque::Worker.smart_id_extractor = -> (job_payload) do
  return nil unless job_payload.is_a?(Hash)

  if job_payload['args'].is_a?(Array) && job_payload['args'].first.is_a?(Hash)
    if job_payload['args'].first['meth'] == 'instance_perform'
      job_payload['args'][2]
    else
      job_payload['args'].first['meth']
    end
  else
    nil
  end
end
```