### PR TITLE
Invert Resque::Worker#shutdown instructions

### DIFF
--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  Version = VERSION = '1.27.4.skroutz.5'
+  Version = VERSION = '1.27.4.skroutz.6'
 end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -422,8 +422,8 @@ module Resque
     # Schedule this worker for shutdown. Will finish processing the
     # current job.
     def shutdown
-      log_with_severity :info, 'Exiting...'
       @shutdown = true
+      log_with_severity :info, 'Exiting...'
     end
 
     # Kill the child and shutdown immediately.


### PR DESCRIPTION
On Wednesday 18/06/2025 we found a pod that logged the `Exiting...` part, but did not log anything else during the execution of the function.

In the original implementation of `#shutdown`,
the log is executed first before the update of the `@shutdown` variable.

With a monkey patch added, we should have logged some info about the caller during shutdown but it logged nothing! It seems that the `#shutdown` function was called but it returned right after the log of `Exiting...`.

A resque worker has the main process and some threads regarding heartbeats. Also resque uses the MonoLogger [1] gem for logging which has an active issue [1] for thread safety since 2013.

We created a theory that there is a race condition between the signal handler, the logger and the threads of the resque worker.

In order to test the theory out, we swapped the lines of the `#shutdown` via a monkey patch.

This somehow seems to fixed the issue confirming our theory about the race condition.

The only problem is that we have not managed to consistently replicate the issue in order to create a better fix.

[1]: https://github.com/steveklabnik/mono_logger
[2]: https://github.com/steveklabnik/mono_logger/issues/2