### PR TITLE
Prevent thundering herd when pruning dead workers

### DIFF
--- a/lib/resque/data_store.rb
+++ b/lib/resque/data_store.rb
@@ -44,6 +44,7 @@ module Resque
                               :heartbeat!,
                               :remove_heartbeat,
                               :all_heartbeats,
+                              :acquire_pruning_dead_worker_lock,
                               :set_worker_payload,
                               :worker_start_time,
                               :worker_done_working
@@ -289,6 +290,10 @@ module Resque
         @redis.hgetall(HEARTBEAT_KEY)
       end
 
+      def acquire_pruning_dead_worker_lock(worker, expiry)
+        @redis.set(redis_key_for_worker_pruning, worker.to_s, :ex => expiry, :nx => true)
+      end
+
       def set_worker_payload(worker, data)
         @redis.set(redis_key_for_worker(worker), data)
       end
@@ -310,6 +315,10 @@ module Resque
 
       def redis_key_for_worker_start_time(worker)
         "#{redis_key_for_worker(worker)}:started"
+      end
+
+      def redis_key_for_worker_pruning
+        "pruning_dead_workers_in_progress"
       end
     end
 

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  Version = VERSION = '1.27.4.skroutz.6'
+  Version = VERSION = '1.27.4.skroutz.7'
 end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -589,6 +589,8 @@ module Resque
     # By checking the current Redis state against the actual
     # environment, we can determine if Redis is old and clean it up a bit.
     def prune_dead_workers
+      return unless data_store.acquire_pruning_dead_worker_lock(self, Resque.heartbeat_interval)
+
       all_workers = Worker.all
 
       unless all_workers.empty?

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -673,6 +673,42 @@ describe "Resque::Worker" do
     assert_equal [], Resque::Worker.all_workers_with_expired_heartbeats
   end
 
+  it "does not prune if another worker has pruned (started pruning) recently" do
+    now = Time.now
+    workerA = Resque::Worker.new(:jobs)
+    workerA.to_s = 'workerA:1:jobs'
+    workerA.register_worker
+    workerA.heartbeat!(now - Resque.prune_interval - 1)
+    assert_equal 1, Resque.workers.size
+    assert_equal [workerA], Resque::Worker.all_workers_with_expired_heartbeats
+
+    workerB = Resque::Worker.new(:jobs)
+    workerB.to_s = 'workerB:1:jobs'
+    workerB.register_worker
+    workerB.heartbeat!(now)
+    assert_equal 2, Resque.workers.size
+
+    workerB.prune_dead_workers
+    assert_equal [], Resque::Worker.all_workers_with_expired_heartbeats
+
+    workerC = Resque::Worker.new(:jobs)
+    workerC.to_s = "workerC:1:jobs"
+    workerC.register_worker
+    workerC.heartbeat!(now - Resque.prune_interval - 1)
+    assert_equal 2, Resque.workers.size
+    assert_equal [workerC], Resque::Worker.all_workers_with_expired_heartbeats
+
+    workerD = Resque::Worker.new(:jobs)
+    workerD.to_s = 'workerD:1:jobs'
+    workerD.register_worker
+    workerD.heartbeat!(now)
+    assert_equal 3, Resque.workers.size
+
+    # workerC does not get pruned because workerB already pruned recently
+    workerD.prune_dead_workers
+    assert_equal [workerC], Resque::Worker.all_workers_with_expired_heartbeats
+  end
+
   it "does not prune workers that haven't set a heartbeat" do
     workerA = Resque::Worker.new(:jobs)
     workerA.to_s = "bar:3:jobs"


### PR DESCRIPTION
This PR backports https://github.com/resque/resque/pull/1594 in our resque fork.

This will improve the pruning of the dead workers preventing multiple reports of the same jobs in the failed queue improving our memory footprint in redis.